### PR TITLE
use Custom Event polyfill for IE11

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,10 +62,26 @@
       (function() {
         'use strict';
 
+        // Polyfill CustomEvent for IE11
+        (function(){
+          if ( typeof window.CustomEvent === "function" ) return false;
+
+          function CustomEvent ( event, params ) {
+            params = params || { bubbles: false, cancelable: false, detail: undefined };
+            var evt = document.createEvent( 'CustomEvent' );
+            evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+            return evt;
+          }
+
+          CustomEvent.prototype = window.Event.prototype;
+
+          window.CustomEvent = CustomEvent;
+        })();
+
         var onload = function() {
           if (!window.HTMLImports) {
             document.dispatchEvent(
-                new CustomEvent('WebComponentsReady', {bubbles: true})
+              new CustomEvent('WebComponentsReady', {bubbles: true})
             );
           }
           loadUserVoice();


### PR DESCRIPTION
The bug: https://trello.com/c/6JuD8dyS/395-ie-compatability-broken-again
The problem seems to be that CustomEvent is an Object in IE9-11 (not a constructor function), so trying to 'new' it fails the same way the screenshots show.
I used the polyfill from here:
https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent